### PR TITLE
correct argument to match documentation

### DIFF
--- a/flashy
+++ b/flashy
@@ -63,7 +63,7 @@ fi
 
 while [[ $# -gt 0 ]] ; do
     case $1 in 
-        -a|--useadb)
+        -a|--adb)
             useadb=true
             shift
             ;;


### PR DESCRIPTION
README and `showHelp` mention --adb and the script expected --useadb.
