### PR TITLE
remote ip added to watch-image

### DIFF
--- a/watch-image
+++ b/watch-image
@@ -44,6 +44,8 @@ Available options:
 -d or --dissect     separates previously saved image into one file per partition
 -h or --help        prints this help screen and quits
 -a or --adb         uses ADB command to communicate with watch
+-p or --port    specifies a port to use for ssh and scp commands
+-R or --remote  specifies the remote (watch)  name or address for ssh and scp commands
 -i or --image FN    uses FN as the file name of the image
 -r or --restore     restore the boot partition of the watch
 -s or --save        save the entire watch image (may be 4G or more!)
@@ -92,7 +94,7 @@ function restorePartition {
             echo "I would have written the ${mypart[3]} partition (starting at ${mypart[1]}, containing ${mypart[2]} sectors) to ${mypart[0]}"
         else
             [ "${quiet}" = "true" ] || echo "Writing the ${mypart[3]} partition (starting at ${mypart[1]}, containing ${mypart[2]} sectors) to ${mypart[0]}"
-            dd if="${imagefile}" skip="${mypart[1]}" count="${mypart[2]}" | ssh root@192.168.2.15 "dd of=${mypart[0]}"
+            dd if="${imagefile}" skip="${mypart[1]}" count="${mypart[2]}" | ssh -p "${WATCHPORT}" root@"${WATCHADDR}" "dd of=${mypart[0]}"
         fi
     fi
 }
@@ -118,10 +120,13 @@ function saveImage {
     if [ "${ADB}" == true ] ; then
         adb pull /dev/mmcblk0 "${imagefile}"
     else
-        ssh root@192.168.2.15 "dd if=/dev/mmcblk0" | dd "of=$(pwd)/${imagefile}" bs=4096 status=progress
+        ssh -p "${WATCHPORT}" root@"${WATCHADDR}" "dd if=/dev/mmcblk0" | dd "of=$(pwd)/${imagefile}" bs=4096 status=progress
     fi
 }
 
+# These are the defaults for SSH access
+WATCHPORT=22
+WATCHADDR=192.168.2.15
 # Assume no ADB unless told otherwise
 ADB=false
 
@@ -129,6 +134,16 @@ while [[ $# -gt 0 ]] ; do
     case $1 in 
         -a|--adb)
             ADB=true
+            shift
+            ;;
+        -p|--port)
+            WATCHPORT="$2"
+            shift
+            shift
+            ;;
+        -R|--remote)
+            WATCHADDR="$2"
+            shift
             shift
             ;;
         -d|--dissect)


### PR DESCRIPTION
copied code from watch-util to watch-image to have consistence to be able to backup and restore with custom ip (usb-ssh not working for me) #my ever 1st contribution, hope it fits

short "-R" for "--remote" needed, due "-r" is already "--restore". to have same on all scripts maybe switch "-R" used for restore?